### PR TITLE
Translated the repository "description" files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,39 @@
-# Contributing to rust-analyzer
+# Contribuyendo a rust-analyzer
 
-Thank you for your interest in contributing to rust-analyzer! There are many ways to contribute
-and we appreciate all of them.
+¡Gracias por tu interés en contribuir a rust-analyzer! Hay muchas maneras de contribuir
+y las apreciamos todas y cada una.
 
-To get a quick overview of the crates and structure of the project take a look at the
-[Contributing](https://rust-analyzer.github.io/book/contributing) section of the manual.
+*Si deseas contribuir una nueva característica a rust-analyzer, visita el [repositorio oficial](https://github.com/rust-lang/rust-analyzer).*
+Este repositorio son únicamente traducciones al idioma español sobre las características
+que provienen de rust-analyzer.
 
-If you have any questions please ask them in the [rust-analyzer zulip stream](
-https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer) or if unsure where
-to start out when working on a concrete issue drop a comment on the related issue for mentoring
-instructions (general discussions are recommended to happen on zulip though).
+Para obtener una vista por encima sobre la estructura y los crates en este repositorio hecha un vistazo a
+la sección del manual [Contributing (inglés)](https://rust-analyzer.github.io/book/contributing).
 
-## Fixing a bug or improving a feature
+Si tienes cualquier pregunta relacionada con rust-analyzer, por favor, pregunta en [rust-analyzer Zulip stream](
+https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer) en caso de no
+estar seguro sobre donde empezar cuando estés trabajando en una issue concreta, escribe un
+comentario con la issue relacionada para mentoría (las discusiones generales es recomendado que
+pasen en Zulip).
 
-Generally it's fine to just work on these kinds of things and put a pull-request out for it. If there
-is an issue accompanying it make sure to link it in the pull request description so it can be closed
-afterwards or linked for context.
 
-If you want to find something to fix or work on keep a look out for the `C-bug` and `C-enhancement`
-labels.
+## Arreglando un bug o mejorando una característica
 
-## Implementing a new feature
+Generalmente, está bien si simplemente trabajas en este tipo de cosas y abres una pull-request para
+ello. Si hay alguna issue acompañando tu solución, asegúrate de adjuntarla en la descripción de la
+pull-request para que sea cerrada posteriormente o simplemente adjuntada para contexto
 
-It's advised to first open an issue for any kind of new feature so the team can tell upfront whether
-the feature is desirable or not before any implementation work happens. We want to minimize the
-possibility of someone putting a lot of work into a feature that is then going to waste as we deem
-it out of scope (be it due to generally not fitting in with rust-analyzer, or just not having the
-maintenance capacity). If there already is a feature issue open but it is not clear whether it is
-considered accepted feel free to just drop a comment and ask!
+Si quieres buscar algo que arreglar o algo en lo que trabajar, busca las etiquetas `C-bug` y
+`C-enchancement` en el [repositorio oficial](https://github.com/rust-lang/rust-analyzer).
+
+
+
+## Implementando una nueva característica
+
+Es recomendado que primero abras una issue, para cualquier tipo de nueva característica, de este
+modo el equipo puede decirte de primeras si la característica es deseada o no, antes de que
+cualquier trabajo de implementación suceda. Queremos minimizar la posibilidad de que alguien ponga
+mucho trabajo en una característica muy grande, y que luego la designemos como que no se alinea
+con el repositorio (generalmente porque la característica no tiene nada que ver con rust-analyzer o
+porque no tenemos los recursos para mantener esta). Si ya hay una issue abierta describiendo lo que
+deseas implementar, ¡Escribe un comentario allí y pregunta!

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,1 +1,1 @@
-See the [Privacy](https://rust-analyzer.github.io/book/privacy.html) section of the user manual.
+Lee la sección [Privacy (inglés)](https://rust-analyzer.github.io/book/privacy.html) del manual de usuario.

--- a/README.md
+++ b/README.md
@@ -4,48 +4,52 @@
     alt="rust-analyzer logo">
 </p>
 
-rust-analyzer is a modular compiler frontend for the Rust language.
-It is a part of a larger rls-2.0 effort to create excellent IDE support for Rust.
+rust-analyzer es un front-end modular para el compilador del Lenguaje de programación Rust.
+Este es parte de un esfuerzo rls-2.0 más grande para crear el soporte perfecto a Rust para IDEs.
 
-## Quick Start
+## Inicio Rápido
 
-https://rust-analyzer.github.io/book/installation.html
+https://rust-analyzer.github.io/book/installation.html (inglés)
 
-## Documentation
+## Documentación
 
-If you want to **contribute** to rust-analyzer check out the [CONTRIBUTING.md](./CONTRIBUTING.md) or
-if you are just curious about how things work under the hood, see the
-[Contributing](https://rust-analyzer.github.io/book/contributing) section of the manual.
+Si quieres **contribuir** a rust-analyzer lee [CONTRIBUTING.md](./CONTRIBUTING.md) o
+si simplemente tienes curiosidad para saber como funcionan las cosas por debajo, mira la
+sección [Contributing (inglés)](https://rust-analyzer.github.io/book/contributing) del manual.
 
-If you want to **use** rust-analyzer's language server with your editor of
-choice, check [the manual](https://rust-analyzer.github.io/book/).
-It also contains some tips & tricks to help you be more productive when using rust-analyzer.
+Si quieres **usar** el servidor de lenguaje de rust-analyzer para tu editor revisa
+[el manual (inglés)](https://rust-analyzer.github.io/book/).
+Este también contiene algunos consejos y trucos para ayudarte a ser más productivo
+mientras usas rust-analyzer.
 
-## Security and Privacy
+## Seguridad y Privacidad
 
-See the [security](https://rust-analyzer.github.io/book/security.html) and
-[privacy](https://rust-analyzer.github.io/book/privacy.html) sections of the manual.
+Este repositorio es un fork al rust-analyzer, si deseas reportar cualquier cosa
+relacionada con la seguridad o privacidad revisa el documento
+[security (inglés)](https://rust-analyzer.github.io/book/security.html) y
+las secciones del manual [privacy (inglés)](https://rust-analyzer.github.io/book/privacy.html)
+para reportar eso al repositorio oficial de rust-analyzer
 
-## Communication
+## Comunicación
 
-For usage and troubleshooting requests, please use "IDEs and Editors" category of the Rust forum:
+Para uso y solicitudes de ayuda, por favor, usa la categoría "IDEs and Editors" del foro de Rust oficial:
 
-https://users.rust-lang.org/c/ide/14
+https://users.rust-lang.org/c/ide/14 (inglés)
 
-For questions about development and implementation, join rust-analyzer working group on Zulip:
+Para preguntas sobre desarrollo e integración, únete al grupo de trabajo rust-analyzer en Zulip:
 
-https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer
+https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer (inglés)
 
-## Quick Links
+## Links rapidos
 
-* Website: https://rust-analyzer.github.io/
-* Metrics: https://rust-analyzer.github.io/metrics/
-* API docs: https://rust-lang.github.io/rust-analyzer/ide/
-* Changelog: https://rust-analyzer.github.io/thisweek
+* Sitio web oficial: https://rust-analyzer.github.io/ (inglés)
+* Métricas: https://rust-analyzer.github.io/metrics/ (inglés)
+* Documentación de la API: https://rust-lang.github.io/rust-analyzer/ide/ (inglés)
+* Registro de cambios: https://rust-analyzer.github.io/thisweek (inglés)
 
 ## License
 
-rust-analyzer is primarily distributed under the terms of both the MIT
-license and the Apache License (Version 2.0).
+rust-analyzer es en mayor parte distribuido bajo los términos de
+las licencias MIT y Apache License (Versión 2.0).
 
-See LICENSE-APACHE and LICENSE-MIT for details.
+Revisa LICENSE-APACHE y LICENSE-MIT para más detalles.


### PR DESCRIPTION
This PR literally translates all the content from `CONTRIBUTING.md`, `PRIVACY.md` and `README.md`, it adds some modifications such as redirections for contributions to go into the official rust-analyzer repository, but it does not add how can they contribute in here as I don't want to define the rules for it myself, now that the files are in Spanish, someone with more word in this repository can modify them with the repository vision and it's alignments.